### PR TITLE
Drush команда для обновления данных из файла

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,20 @@ composer run-script phpstan
 ```php
 composer run-script phpcs
 ```
+
+### Drush Commands
+
+### druki-content:sync-file
+
+The command `druki-content:sync-file` allows you to run import/update process for the specific file. Expects filepath to the file which should be processed relative to content source path.
+
+**Options:**
+
+* `locale`: The langcode which used for content. By default, uses sites default.
+
+Examples:
+
+```bash
+drush druki-content:sync-file docs/ru/drupal/index.md
+drush druki-content:sync-file docs/ru/drupal/index.md --locale=en
+```

--- a/web/modules/custom/druki_content/drush.services.yml
+++ b/web/modules/custom/druki_content/drush.services.yml
@@ -1,0 +1,9 @@
+services:
+  druki_content.sync.commands:
+    class: Drupal\druki_content\Commands\DrukiContentSyncCommands
+    tags:
+      - { name: drush.command }
+    arguments:
+      - '@druki_git'
+      - '@language_manager'
+      - '@druki_content.sync_queue_processor.source_content_list'

--- a/web/modules/custom/druki_content/src/Commands/DrukiContentSyncCommands.php
+++ b/web/modules/custom/druki_content/src/Commands/DrukiContentSyncCommands.php
@@ -54,7 +54,7 @@ class DrukiContentSyncCommands extends DrushCommands {
   }
 
   /**
-   * Synchronization one entity.
+   * Synchronization one entity by source file.
    *
    * @param string $uri
    *   The URI to source file.
@@ -62,12 +62,12 @@ class DrukiContentSyncCommands extends DrushCommands {
    *   An associative array of options.
    *
    * @option locale A short language code.
-   * @command druki:sync:uri
+   * @command druki-content:sync-file
    *
-   * @usage drush druki:sync:uri docs/ru/drupal/9/routing/index.md --locale=ru
+   * @usage drush druki-content:sync-file docs/ru/drupal/9/routing/index.md --locale=ru
    *   Create/Update entity URI to source file.
    */
-  public function syncUri(string $uri, array $options = ['locale' => NULL]): void {
+  public function syncFile(string $uri, array $options = ['locale' => NULL]): void {
     $realPath = \rtrim($this->gitService->getRepositoryRealpath(), "/");
     $realPath .= '/' . \ltrim($uri, "/");
     $locale = $options['locale'];

--- a/web/modules/custom/druki_content/src/Commands/DrukiContentSyncCommands.php
+++ b/web/modules/custom/druki_content/src/Commands/DrukiContentSyncCommands.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\druki_content\Commands;
+
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\druki_content\Sync\Queue\QueueProcessorInterface;
+use Drupal\druki_content\Sync\SourceContent\SourceContent;
+use Drupal\druki_content\Sync\SourceContent\SourceContentList;
+use Drupal\druki_content\Sync\SourceContent\SourceContentListQueueItem;
+use Drupal\druki_git\Git\GitInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Provides drush commands for synchronization "druki_content" entity.
+ */
+class DrukiContentSyncCommands extends DrushCommands {
+
+  /**
+   * The git service.
+   *
+   * @var \Drupal\druki_git\Git\GitInterface
+   */
+  protected $gitService;
+
+  /**
+   * The language manager service.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * The queue item processors.
+   *
+   * @var \Drupal\druki_content\Sync\Queue\QueueProcessorInterface
+   */
+  protected $queueProcessor;
+
+  /**
+   * DrukiContentSyncCommands constructor.
+   *
+   * @param \Drupal\druki_git\Git\GitInterface $gitService
+   *   The git service.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   The language manager service.
+   * @param \Drupal\druki_content\Sync\Queue\QueueProcessorInterface $queueProcessor
+   *   The queue item processors.
+   */
+  public function __construct(GitInterface $gitService, LanguageManagerInterface $languageManager, QueueProcessorInterface $queueProcessor) {
+    parent::__construct();
+    $this->gitService = $gitService;
+    $this->languageManager = $languageManager;
+    $this->queueProcessor = $queueProcessor;
+  }
+
+  /**
+   * Synchronization one entity.
+   *
+   * @param string $uri
+   *   The URI to source file.
+   * @param array $options
+   *   An associative array of options.
+   *
+   * @option locale A short language code.
+   * @command druki:sync:uri
+   *
+   * @usage drush druki:sync:uri docs/ru/drupal/9/routing/index.md --locale=ru
+   *   Create/Update entity URI to source file.
+   */
+  public function syncUri(string $uri, array $options = ['locale' => NULL]): void {
+    $realPath = \rtrim($this->gitService->getRepositoryRealpath(), "/");
+    $realPath .= '/' . \ltrim($uri, "/");
+    $locale = $options['locale'];
+    if (empty($locale)) {
+      $activeLanguage = $this->languageManager->getDefaultLanguage();
+      $locale = $activeLanguage->getId();
+    }
+    $sourceContent = new SourceContent($realPath, $uri, $locale);
+    $sourceContentList = (new SourceContentList())->add($sourceContent);
+    $this->queueProcessor->process(new SourceContentListQueueItem($sourceContentList));
+  }
+
+}


### PR DESCRIPTION
Этот ПР предоставляет Drush команду для импорт/обновления сущности непосредственно из файла.
Пример команды `drush druki:sync:uri docs/ru/drupal/9/routing/index.md` путь указывается относительно каталога репозитория с исходными файлами.

Например: 

Если каталог репозитория указан как `public://druki-content-source` и в команде указан URI файла как `docs/ru/drupal/9/routing/index.md` то фактически файл должен находится по пути `public://druki-content-source/docs/ru/drupal/9/routing/index.md`