### PR TITLE
Поле категория

### DIFF
--- a/web/modules/custom/druki_content/src/Sync/ParsedContent/FrontMatter/FrontMatterLoader.php
+++ b/web/modules/custom/druki_content/src/Sync/ParsedContent/FrontMatter/FrontMatterLoader.php
@@ -68,6 +68,9 @@ final class FrontMatterLoader extends ParsedContentItemLoaderBase {
 
       $content->setCategory($category_area, $category_order, $category_title);
     }
+    else {
+      $content->set('category', NULL);
+    }
   }
 
   /**


### PR DESCRIPTION
Сброс значения поля "категория" если не было найдено соответствующего FrontMatter ключа.

**Воспроизведение**
1. Создаем `index.md` файл с ключом `category`;
2. Синхронизация;
3. Удаляем ключ `category` из файла в п1;
4. Синхронизация.
Ожидается что поле `category` должно быть пустым. но такого не происходит.