### PR TITLE
Валидация Front Matter

### DIFF
--- a/web/modules/custom/druki/src/Markdown/CommonMark/Block/Renderer/FrontMatterRenderer.php
+++ b/web/modules/custom/druki/src/Markdown/CommonMark/Block/Renderer/FrontMatterRenderer.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\druki\Markdown\CommonMark\Block\Renderer;
 
+use Drupal\Component\FrontMatter\Exception\FrontMatterParseException;
+use Drupal\Component\Serialization\Exception\InvalidDataTypeException;
 use Drupal\Core\Serialization\Yaml;
 use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
@@ -18,7 +20,12 @@ final class FrontMatterRenderer implements BlockRendererInterface {
    */
   public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, $inTightList = FALSE): HtmlElement {
     $content = [];
-    $yaml_array = Yaml::decode($block->getStringContent());
+    try {
+      $yaml_array = Yaml::decode($block->getStringContent());
+    }
+    catch (InvalidDataTypeException $e) {
+      throw new FrontMatterParseException($e);
+    }
 
     foreach ($yaml_array as $key => $value) {
       $content[$key] = $value;

--- a/web/modules/custom/druki_content/druki_content.services.yml
+++ b/web/modules/custom/druki_content/druki_content.services.yml
@@ -37,7 +37,7 @@ services:
   druki_content.sync_queue_processor.source_content_list:
     class: Drupal\druki_content\Sync\SourceContent\SourceContentListQueueProcessor
     public: false
-    arguments: ['@state', '@druki_content.source_content_parser', '@druki_content.parsed_source_content_loader']
+    arguments: ['@state', '@druki_content.source_content_parser', '@druki_content.parsed_source_content_loader', '@logger.channel.druki_content']
     tags:
       - { name: druki_sync_queue_processor }
 


### PR DESCRIPTION
Реализовал пропуск очереди если были ошибки парсинга Front Matter блока.
1. Ловим исключение при парсинге Front Matter. (исключение от YAML парсера)
2. Выбрасываем исключение ошибка парсингна Front Matter. (исключение для Front Matter)
3. Ловим наше исключение из п2.
4. Логируем, что была ошибка парсинга и пропущен файл

Результат:
```
> drush queue:run druki_content_sync                             
 [warning] File "docs/ru/drupal/9/routing/index.md" skipped. Error parsing front matter block. Text error: "An error occurred when attempting to parse front matter data on line 14"
 [success] Processed 7 items from the druki_content_sync queue in 150.26 sec.

```